### PR TITLE
Remove unused code from the class

### DIFF
--- a/config/Common.php
+++ b/config/Common.php
@@ -39,7 +39,6 @@ class Common extends Config
          */
         $di->setter['Aura\Bin\Command\Release2']['setPhpdoc'] = $di->lazyNew('Aura\Bin\Shell\Phpdoc');
         $di->setter['Aura\Bin\Command\Release2']['setPhpunit'] = $di->lazyNew('Aura\Bin\Shell\Phpunit');
-        $di->setter['Aura\Bin\Command\Release2']['setMailer'] = $di->lazyNew('Aura\Bin\Mailer');
         $di->setter['Aura\Bin\Command\Release2']['setIronMQ'] = $di->lazyNew('IronMQ\IronMQ');
         $di->setter['Aura\Bin\Command\Release2']['setTweeter'] = $di->lazyNew('Aura\Bin\Tweeter');
 
@@ -48,7 +47,6 @@ class Common extends Config
          */
         $di->setter['Aura\Bin\Command\Release3']['setPhpdoc'] = $di->lazyNew('Aura\Bin\Shell\Phpdoc');
         $di->setter['Aura\Bin\Command\Release3']['setPhpunit'] = $di->lazyNew('Aura\Bin\Shell\Phpunit');
-        $di->setter['Aura\Bin\Command\Release3']['setMailer'] = $di->lazyNew('Aura\Bin\Mailer');
         $di->setter['Aura\Bin\Command\Release3']['setIronMQ'] = $di->lazyNew('IronMQ\IronMQ');
         $di->setter['Aura\Bin\Command\Release3']['setTweeter'] = $di->lazyNew('Aura\Bin\Tweeter');
 

--- a/src/Command/Release2.php
+++ b/src/Command/Release2.php
@@ -37,8 +37,6 @@ class Release2 extends AbstractCommand
 
     protected $phpunit;
 
-    protected $mailer;
-
     protected $ironmq;
 
     protected $tweeter;
@@ -51,11 +49,6 @@ class Release2 extends AbstractCommand
     public function setPhpunit($phpunit)
     {
         $this->phpunit = $phpunit;
-    }
-
-    public function setMailer($mailer)
-    {
-        $this->mailer = $mailer;
     }
 
     public function setIronMQ($ironmq)
@@ -293,7 +286,6 @@ class Release2 extends AbstractCommand
         $this->stdio->outln('Getting the tagged release.');
         $this->shell('git pull');
 
-        // $this->followupEmail();
         $this->followupEmailToQueue();
         $this->followupTweet();
     }
@@ -308,31 +300,6 @@ class Release2 extends AbstractCommand
             'changes' => $changes
         );
         $this->ironmq->postMessage('notifications', json_encode($data));
-    }
-
-    protected function followupEmail()
-    {
-        $this->stdio->out('Notifying the mailing list ... ');
-
-        $to = 'auraphp@googlegroups.com';
-        $subject = "New Release: {$this->package} {$this->version}";
-        $changes = trim(file_get_contents('CHANGES.md'));
-        $body = <<<BODY
-Hi everyone!
-
-We have just released {$this->package} version {$this->version}. You can get it from the usual location at <https://github.com/auraphp/{$this->package}/releases>, or update `composer.json` with the new version number.
-
-{$changes}
-
-Please let us know if you have any questions, comments, or concerns about this or any other release.  And thanks, as always, for supporting Aura!
-
-BODY;
-        $result = $this->mailer->send($to, $subject, $body);
-        if (! $result) {
-            $this->stdio->outln('failure.');
-        } else {
-            $this->stdio->outln('success.');
-        }
     }
 
     protected function followupTweet()

--- a/src/Command/Release3.php
+++ b/src/Command/Release3.php
@@ -36,8 +36,6 @@ class Release3 extends AbstractCommand
 
     protected $phpunit;
 
-    protected $mailer;
-
     protected $ironmq;
 
     protected $tweeter;
@@ -50,11 +48,6 @@ class Release3 extends AbstractCommand
     public function setPhpunit($phpunit)
     {
         $this->phpunit = $phpunit;
-    }
-
-    public function setMailer($mailer)
-    {
-        $this->mailer = $mailer;
     }
 
     public function setIronMQ($ironmq)


### PR DESCRIPTION
This remove the mailer functionality so that next time no emails itself is send other than via calling `send-email`.

@pmjones one doubt : aren't you calling the  `php cli/console.php send-email` functionality only at the end after you release every package? or did you accidentally called `send-email` after each package is released?