### PR TITLE
Build the CHANGELOG.md file from old tags

### DIFF
--- a/config/Common.php
+++ b/config/Common.php
@@ -137,6 +137,7 @@ class Common extends Config
             'repos'              => $di->lazyNew('Aura\Bin\Command\Repos'),
             'send-email'         => $di->lazyNew('Aura\Bin\Command\SendEmail'),
             'travis'             => $di->lazyNew('Aura\Bin\Command\Travis'),
+            'create-changelog'   => $di->lazyNew('Aura\Bin\Command\CreateChangelog'),
         ));
     }
 

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -78,4 +78,13 @@ abstract class AbstractCommand
         preg_match("/$format/", $version, $matches);
         return (bool) $matches;
     }
+
+    protected function getChangeLogContents()
+    {
+        if (preg_match('/##\s(\d+.\d+.\d+)(-(dev|alpha\d+|beta\d+|RC\d+))?([\s\S]*?)##\s(\d+.\d+.\d+)(-(dev|alpha\d+|beta\d+|RC\d+))?/s', file_get_contents('CHANGELOG.md'), $matches, PREG_OFFSET_CAPTURE, 1)) {
+            return $matches[4][0];
+        }
+
+        $this->stdio->outln('Changes not found in CHANGELOG.md.');
+    }
 }

--- a/src/Command/CreateChangelog.php
+++ b/src/Command/CreateChangelog.php
@@ -35,7 +35,7 @@ class CreateChangelog extends AbstractCommand
 
     protected function getChanges($version)
     {
-        if (version_compare($version, '2.0.0-beta', '>=')) {
+        if (version_compare($version, '2.0.0-alpha', '>=')) {
             // >= 2.0.0
             $file = 'CHANGES.md';
         } else {

--- a/src/Command/CreateChangelog.php
+++ b/src/Command/CreateChangelog.php
@@ -1,0 +1,49 @@
+<?php
+namespace Aura\Bin\Command;
+
+use Aura\Bin\Exception;
+
+class CreateChangelog extends AbstractCommand
+{
+    public function __invoke()
+    {
+        $tags = $this->gitTags();
+        $changes = "# CHANGELOG \n\n";
+        foreach ($tags as $key => $tag) {
+            if (basename(getcwd()) == "Aura.Router") {
+                if (in_array($tag, ['3.0.0-alpha1','3.0.0-alpha2'])) {
+                    // skip for these versions. There is no changelog
+                    continue;
+                }
+            }
+            $changes .= '## ' . $tag . "\n\n";
+            $changes .= implode("\n", $this->getChanges($tag)) . "\n\n";
+        }
+
+        file_put_contents('CHANGELOG.md', $changes);
+
+        $this->stdio->outln('Changelog file created from older versions.');
+    }
+
+    protected function gitTags()
+    {
+        exec('git tag --list', $versions);
+        usort($versions, 'version_compare');
+
+        return array_reverse($versions);
+    }
+
+    protected function getChanges($version)
+    {
+        if (version_compare($version, '2.0.0-beta', '>=')) {
+            // >= 2.0.0
+            $file = 'CHANGES.md';
+        } else {
+            $file = 'meta/changes.txt';
+        }
+
+        exec("git show {$version}:./{$file}", $output, $return);
+
+        return $output;
+    }
+}

--- a/src/Command/Release2.php
+++ b/src/Command/Release2.php
@@ -114,7 +114,7 @@ class Release2 extends AbstractCommand
     {
         $files = array(
             '.travis.yml',
-            'CHANGES.md',
+            'CHANGELOG.md',
             'CONTRIBUTING.md',
             'LICENSE',
             'README.md',
@@ -144,18 +144,18 @@ class Release2 extends AbstractCommand
         $src_timestamp = $this->gitDateToTimestamp($output);
 
         // now read the log for meta/changes.txt
-        $this->stdio->outln('Last log on CHANGES.md:');
-        $this->shell('git log -1 CHANGES.md', $output, $return);
+        $this->stdio->outln('Last log on CHANGELOG.md:');
+        $this->shell('git log -1 CHANGELOG.md', $output, $return);
         $changes_timestamp = $this->gitDateToTimestamp($output);
 
         // which is older?
         if ($src_timestamp > $changes_timestamp) {
             $since = date('D M j H:i:s Y', $changes_timestamp);
             $this->stdio->outln('');
-            $this->stdio->outln('File CHANGES.md is older than src/ .');
+            $this->stdio->outln('File CHANGELOG.md is older than src/ .');
             $this->stdio->outln("Add changes from the log ...");
             $this->stdio->outln("    git log --name-only --since='$since' --reverse");
-            $this->stdio->outln('... then commit the CHANGES.md file.');
+            $this->stdio->outln('... then commit the CHANGELOG.md file.');
             return false;
         }
 
@@ -269,7 +269,7 @@ class Release2 extends AbstractCommand
             'tag_name' => $this->version,
             'target_commitish' => $this->branch,
             'name' => $this->version,
-            'body' => file_get_contents('CHANGES.md'),
+            'body' => $this->getChangeLogContents();,
             'draft' => false,
             'prerelease' => false,
         );
@@ -293,7 +293,7 @@ class Release2 extends AbstractCommand
     protected function followupEmailToQueue()
     {
         $this->stdio->out('Queuing an email to the mailing list ... ');
-        $changes = trim(file_get_contents('CHANGES.md'));
+        $changes = trim($this->getChangeLogContents(););
         $data = array(
             'package' => $this->package,
             'version' => $this->version,

--- a/src/Command/Release3.php
+++ b/src/Command/Release3.php
@@ -113,7 +113,7 @@ class Release3 extends AbstractCommand
     {
         $files = array(
             '.travis.yml',
-            'CHANGES.md',
+            'CHANGELOG.md',
             'CONTRIBUTING.md',
             'LICENSE',
             'README.md',
@@ -143,18 +143,18 @@ class Release3 extends AbstractCommand
         $src_timestamp = $this->gitDateToTimestamp($output);
 
         // now read the log for meta/changes.txt
-        $this->stdio->outln('Last log on CHANGES.md:');
-        $this->shell('git log -1 CHANGES.md', $output, $return);
+        $this->stdio->outln('Last log on CHANGELOG.md:');
+        $this->shell('git log -1 CHANGELOG.md', $output, $return);
         $changes_timestamp = $this->gitDateToTimestamp($output);
 
         // which is older?
         if ($src_timestamp > $changes_timestamp) {
             $since = date('D M j H:i:s Y', $changes_timestamp);
             $this->stdio->outln('');
-            $this->stdio->outln('File CHANGES.md is older than last commit.');
+            $this->stdio->outln('File CHANGELOG.md is older than last commit.');
             $this->stdio->outln("Add changes from the log ...");
             $this->stdio->outln("    git log --name-only --since='$since' --reverse");
-            $this->stdio->outln('... then commit the CHANGES.md file.');
+            $this->stdio->outln('... then commit the CHANGELOG.md file.');
             return false;
         }
 
@@ -252,7 +252,7 @@ class Release3 extends AbstractCommand
             'tag_name' => $this->version,
             'target_commitish' => $this->branch,
             'name' => $this->version,
-            'body' => file_get_contents('CHANGES.md'),
+            'body' => $this->getChangeLogContents();,
             'draft' => false,
             'prerelease' => false,
         );
@@ -276,7 +276,7 @@ class Release3 extends AbstractCommand
     protected function followupEmailToQueue()
     {
         $this->stdio->out('Queuing an email to the mailing list ... ');
-        $changes = trim(file_get_contents('CHANGES.md'));
+        $changes = trim($this->getChangeLogContents(););
         $data = array(
             'package' => $this->package,
             'version' => $this->version,


### PR DESCRIPTION
Hi @pmjones ,

I have been thinking to release the Aura.Intl 2.x series before cake releases its next versions. 

From our earlier discussion, there was an idea of keeping CHANGELOG.md than changes.md being replaced.

The first step of creating CHANGELOG.md from older versions is done.

Eg generated for Aura.Router : 

```
# CHANGELOG 

## 3.0.1

Hygiene release: update docs, remove .gitattributes file.

## 3.0.0

First stable release.

- Default factories now use serializable method calls.

- Honor the route host and the secure flag in Generator.

## 3.0.0-beta2

First 3.x beta release.

## 3.0.0-beta1

First 3.x beta release.

## 2.3.1

Hygiene release to update docblocks.

## 2.3.0

This release adds support for a "base path" to routes. See #84, #86, and #96 for background and information. Thanks to @pine3ree and @harikt for their foundational work on this feature!

## 2.2.2

This release modifies the testing structure and updates other support files.

## 2.2.1

This is a hygiene release to update support files and documentation, with improved unit tests.

## 2.2.0

- ADD: Allow easier specification of $values['action'] directly from
  RouteCollection::add*() by passing a third param as the action value.

## 2.1.2

- DOC: Update README and docblocks.

- TST: Disable auto-resolve for container tests.


## 2.1.1

- FIX: Allow simplest possible match of a single Accept header type without a Q value.

## 2.1.0

- ADD: Router::generateRaw() to generate routes with raw data.

- TST: Add container integration tests.

## 2.0.0

First stable 2.0 release.

- DOC: Update README and docblocks.

- ADD: Methods Route::setAccept() and Route::addAccept() to match against "Accept" headers.

- ADD: Methods Route::setMethod() and Route::addMethod() to explicitly match against HTTP methods.

- ADD: Testing on Travis for PHP 5.6.

- ADD: Method Router::addHead() to add a HEAD route

- ADD: Methods Router::getFailedRoute(), Route::failedMethod(), and Route::failedAccept(), along with route match scoring, to inspect the closest non-matching route.

- REF: Various refactorings to extract complex code to separate classes

- BRK: The routes no longer add a "controller" value by default; instead, they add only an "action" value that defaults to the route name. This makes the package ADR-centric by default instead of MVC-centric.

- CHG: Use ArrayObject for value matches

- CHG: Method Router::attachResource() now adds an "OPTIONS" route.

- REF: Extract a Generator class from the Route class

- ADD: Generator::generateRaw() to use **raw** values in the route; you will need to encode them yourself.

- ADD: Method Router::getMatchedRoute() for use after matching.

- ADD: Class-based config for Aura.*_Kernel packages.

## 2.0.0-beta1

Initial 2.0 beta release.

## 1.2.0

- Add methods Map::appendMap() and Map::prependMap(), to append or prepend the definitions from another map.

- Add test for Route::__isset()

- Remove 'router_map' service from config; leave this for the framework-level config

## 1.1.1

- [DOC] Add PHP 5.5 to Travis build, update README and LICENSE.

- [ADD] Route::__isset()

- [CHG] Route::attach() now works with an empty path

## 1.1.0

- [CHG] Altered implementation of Route::generate() to encode param tokens
  using rawurlencode() instead of urlencode().

- [CHG] Altered the implementation of Route::isMatch() to decode matching
  parameters using rawurlencode().

- [CHG] In Route::generate(), use strtr() instead of str_replace() as a more
  secure mechanism

- [NEW] Specific exceptions: RouteNotFound and UnexpectedType

- [CHG] Map now throws UnexpectedType when attach route spec is bad

- [BRK] Map now throws RouteNotFound when generate() cannot find the named
  route

- [CHG] Docblock and README changes from Akihito Koriyama, Hari KT, and Stan
  Lemon

- [CHG] Map::match() now requires the $server param to be passed

- [ADD] New notation for wildcard matching; in addition to /*, we now have
  {:foo*} for optional wildcard params, and {:foo+} for required wildcard
  params. Thanks, Chris Doherty, for the report that led to this feature.

## 1.0.0

- [FIX] #14, misnamed routes. thanks kevinard.
  https://github.com/auraphp/Aura.Router/issues/14

- [ADD] Wildcard support per #15.
  https://github.com/auraphp/Aura.Router/issues/15

- [FIX] Allow for a trailing slash with no values.

- [FIX] Make it so path_prefix ending with / and path beginning with / does
  not result in double-slashes

- [CHG] Start using a Definition object

- [CHG] Allow 'attach' definitions to be callables

```

There can be special cases that we need to adjust, but it will show in long run.

Let me know if you have a different naming suggestion for commands.

Thank you